### PR TITLE
Fix: Update to Claude Haiku 4.5 model

### DIFF
--- a/docs/PHASE_4.2_SUMMARY.md
+++ b/docs/PHASE_4.2_SUMMARY.md
@@ -20,7 +20,7 @@ Implemented Twilio ConversationRelay incoming call handler and webhook for the W
 - Points to conversation-relay webhook endpoint
 
 **Key Configuration:**
-- Model: `claude-3-5-sonnet-20241022`
+- Model: `claude-haiku-4-5`
 - Temperature: 0.7
 - Max Tokens: 1024
 - Voice: `{ provider: 'amazon-polly', voice: 'Joanna', engine: 'neural' }`

--- a/src/functions/README.md
+++ b/src/functions/README.md
@@ -163,7 +163,7 @@ curl -X POST http://localhost:3000/conversation-relay \
 
 ### AI Provider Settings
 - **Provider**: Anthropic
-- **Model**: claude-3-5-sonnet-20241022
+- **Model**: claude-haiku-4-5
 - **Temperature**: 0.7
 - **Max Tokens**: 1024
 

--- a/src/functions/conversation-relay.js
+++ b/src/functions/conversation-relay.js
@@ -168,7 +168,7 @@ async function handleSetup(context, event, response, callback) {
       config: {
         provider: {
           name: "anthropic",
-          model: "claude-3-5-sonnet-20241022",
+          model: "claude-haiku-4-5",
           temperature: 0.7,
           max_tokens: 1024,
         },
@@ -185,7 +185,7 @@ async function handleSetup(context, event, response, callback) {
       config: {
         provider: {
           name: "anthropic",
-          model: "claude-3-5-sonnet-20241022",
+          model: "claude-haiku-4-5",
           temperature: 0.7,
           max_tokens: 1024,
         },
@@ -247,7 +247,7 @@ async function handlePrompt(context, event, response, callback) {
 
     // Call Claude API
     const claudeResponse = await anthropic.messages.create({
-      model: "claude-3-5-sonnet-20241022",
+      model: "claude-haiku-4-5",
       max_tokens: 1024,
       temperature: 0.7,
       system: fullSystemPrompt,


### PR DESCRIPTION
Fixes the 404 model not found error by updating from invalid model name `claude-3-5-sonnet-20241022` to `claude-haiku-4-5`.

## Problem
Calls were failing with:
```
Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-5-sonnet-20241022"}}
```

## Solution
Updated to Claude Haiku 4.5 which is:
- 2x faster than Sonnet (better for voice calls)
- 3x cheaper (/MTok input vs /MTok)
- Perfect for real-time chat and voice applications

## Changes
- Updated model name in `conversation-relay.js` (3 occurrences)
- Updated documentation in README and PHASE_4.2_SUMMARY

## Testing
Verified with Wrangler logs showing the 404 error on previous calls.